### PR TITLE
Mirror of haskell ghcide#744

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -86,7 +86,7 @@ library
         ghc-check,
         ghc-paths,
         cryptohash-sha1 >=0.11.100 && <0.12,
-        hie-bios == 0.6.*,
+        hie-bios >= 0.6.0 && < 0.8.0,
         base16-bytestring >=0.1.1 && <0.2
     if os(windows)
       build-depends:
@@ -272,7 +272,7 @@ executable ghcide
         hashable,
         haskell-lsp,
         haskell-lsp-types,
-        hie-bios >= 0.6.0 && < 0.7,
+        hie-bios >= 0.6.0 && < 0.8,
         ghcide,
         optparse-applicative,
         text,


### PR DESCRIPTION
Mirror of haskell ghcide#744
```
16:18 <maralorn> Should I expect any trouble when building current ghcide (hls-3 branch to be precise) with hie-bios 0.7.0?
16:19 <maralorn> Apparently it does compile without issues.
16:21 <fendor> maralorn, no, the breaking change is in the config type, which neither hls nor ghcide explicltly use
16:21 <fendor> so, everything should just work fine for both these projects
```
I tested. This builds with newest hie-bios for me.
